### PR TITLE
Fix first time start fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,8 @@ module.exports = class RemindMe extends Plugin {
   }
 
   get() {
-    return JSON.parse(this.settings.get("reminders"));
+    const set = this.settings.get("reminders")
+    return set ? JSON.parse(set) : false;
   }
 
   apply(message, duration) {


### PR DESCRIPTION
When I started this plugin, it kept on causing an issue about not being able to parse undefined. This PR fixes it.